### PR TITLE
Add Regrouping by Regex Feature to Kronos CLI for Enhanced Flexibility

### DIFF
--- a/cmd/forceSleep/off.go
+++ b/cmd/forceSleep/off.go
@@ -27,7 +27,7 @@ var offCmd = &cobra.Command{
 Example:
 $ kronos-cli forceSleep off --name=my-kronosapp --namespace=my-namespace`,
 	Run: func(cmd *cobra.Command, args []string) {
-		spec := "sleep"
+		spec := "ForceSleep"
 		action := "off"
 
 		flags, err := utils.GetFlagNames(cmd)
@@ -65,11 +65,11 @@ $ kronos-cli forceSleep off --name=my-kronosapp --namespace=my-namespace`,
 }
 
 func init() {
-	onCmd.Flags().StringVarP(&resourceNameOff, "name", "n", "", "The KronosApp name you want to modify")
-	onCmd.Flags().StringVarP(&resourceNamespaceOff, "namespace", "", "", "The KronosApp namespace you want to modify")
-	onCmd.Flags().StringVarP(&matchRegexOff, "match-regex", "", "", "Pattern, applied on name, used to regroup KronosApps you want to modify")
+	offCmd.Flags().StringVarP(&resourceNameOff, "name", "n", "", "The KronosApp name you want to modify")
+	offCmd.Flags().StringVarP(&resourceNamespaceOff, "namespace", "", "default", "The KronosApp namespace you want to modify")
+	offCmd.Flags().StringVarP(&matchRegexOff, "match-regex", "", "", "Pattern, applied on name, used to regroup KronosApps you want to modify")
 
-	onCmd.PreRunE = func(cmd *cobra.Command, args []string) error {
+	offCmd.PreRunE = func(cmd *cobra.Command, args []string) error {
 		if matchRegexOff != "" {
 			if resourceNameOff != "" {
 				return fmt.Errorf("the --match-regex flag cannot be used with the --name flag")

--- a/cmd/forceSleep/off.go
+++ b/cmd/forceSleep/off.go
@@ -5,14 +5,17 @@ package forceSleep
 
 import (
 	"fmt"
+	"os"
+	"regexp"
+
 	"github.com/KronosOrg/kronos-cli/cmd/utils"
 	"github.com/spf13/cobra"
-	"os"
 )
 
 var (
 	resourceNameOff      string
 	resourceNamespaceOff string
+	matchRegexOff        string
 )
 
 // offCmd represents the off command
@@ -24,44 +27,59 @@ var offCmd = &cobra.Command{
 Example:
 $ kronos-cli forceSleep off --name=my-kronosapp --namespace=my-namespace`,
 	Run: func(cmd *cobra.Command, args []string) {
-		name, namespace, err := utils.GetFlagNames(cmd)
+		spec := "sleep"
+		action := "off"
+
+		flags, err := utils.GetFlagNames(cmd)
 		if err != nil {
-			fmt.Println("ERROR", err)
+			fmt.Println(err)
 		}
-		fmt.Printf("Deactivating ForceSleep on KronosApp: name=%s in namespace=%s \n", name, namespace)
+
+		regexPattern := flags[0]
+		namespace := flags[1]
+		name := flags[2]
+
 		err, client := utils.InitializeClientConfig()
 		if err != nil {
 			fmt.Println("ERROR", err)
 			os.Exit(1)
 		}
-		crdApi := utils.GetCrdApiUrl(name, namespace)
-		err, sd := utils.GetKronosAppByName(client, crdApi)
-		if err != nil {
-			fmt.Println("ERROR", err)
-			os.Exit(1)
-		}
-		if !sd.Spec.ForceSleep {
-			fmt.Println(utils.GetWarningMessage("ForceSleep", "off", name))
+
+		if regexPattern != "" {
+			regex := regexp.MustCompile(regexPattern)
+			err = utils.ApplyActionOnSpecByPattern(client, *regex, namespace, spec, action)
+			if err != nil {
+				fmt.Println("ERROR", err)
+				os.Exit(1)
+			}
+			os.Exit(0)
+		} else {
+			err = utils.ApplyActionOnSpecByName(client, name, namespace, spec, action)
+			if err != nil {
+				fmt.Println("ERROR", err)
+				os.Exit(1)
+			}
 			os.Exit(0)
 		}
-		err = utils.PerformingActionOnSpec(client, &sd, crdApi, "sleep", "off")
-		if err != nil {
-			fmt.Println("ERROR ", err)
-			os.Exit(1)
-		}
-		fmt.Println(utils.GetSuccessMessage("ForceSleep", "off", name))
 	},
 }
 
 func init() {
-	offCmd.Flags().StringVarP(&resourceNameOff, "name", "n", "", "The KronosApp name you want to modify")
-	offCmd.Flags().StringVarP(&resourceNamespaceOff, "namespace", "", "", "The KronosApp namespace you want to modify")
+	onCmd.Flags().StringVarP(&resourceNameOff, "name", "n", "", "The KronosApp name you want to modify")
+	onCmd.Flags().StringVarP(&resourceNamespaceOff, "namespace", "", "", "The KronosApp namespace you want to modify")
+	onCmd.Flags().StringVarP(&matchRegexOff, "match-regex", "", "", "Pattern, applied on name, used to regroup KronosApps you want to modify")
 
-	if err := offCmd.MarkFlagRequired("name"); err != nil {
-		fmt.Println(err)
-	}
-	if err := offCmd.MarkFlagRequired("namespace"); err != nil {
-		fmt.Println(err)
+	onCmd.PreRunE = func(cmd *cobra.Command, args []string) error {
+		if matchRegexOff != "" {
+			if resourceNameOff != "" {
+				return fmt.Errorf("the --match-regex flag cannot be used with the --name flag")
+			}
+		} else {
+			if resourceNameOff == "" || resourceNamespaceOff == "" {
+				return fmt.Errorf("both --name and --namespace flags are required unless --match-regex is used")
+			}
+		}
+		return nil
 	}
 
 	ForceSleepCmd.AddCommand(offCmd)

--- a/cmd/forceSleep/on.go
+++ b/cmd/forceSleep/on.go
@@ -28,7 +28,7 @@ Example:
 $ kronos-cli forceSleep on --name=my-kronosap --namespace=my-namespace`,
 
 	Run: func(cmd *cobra.Command, args []string) {
-		spec := "sleep"
+		spec := "ForceSleep"
 		action := "on"
 
 		flags, err := utils.GetFlagNames(cmd)

--- a/cmd/forceSleep/on.go
+++ b/cmd/forceSleep/on.go
@@ -6,6 +6,7 @@ package forceSleep
 import (
 	"fmt"
 	"os"
+	"regexp"
 
 	"github.com/KronosOrg/kronos-cli/cmd/utils"
 	"github.com/spf13/cobra"
@@ -14,6 +15,7 @@ import (
 var (
 	resourceNameOn      string
 	resourceNamespaceOn string
+	matchRegexOn        string
 )
 
 // onCmd represents the on command
@@ -26,44 +28,59 @@ Example:
 $ kronos-cli forceSleep on --name=my-kronosap --namespace=my-namespace`,
 
 	Run: func(cmd *cobra.Command, args []string) {
-		name, namespace, err := utils.GetFlagNames(cmd)
+		spec := "sleep"
+		action := "on"
+
+		flags, err := utils.GetFlagNames(cmd)
 		if err != nil {
-			fmt.Println("ERROR", err)
+			fmt.Println(err)
 		}
-		fmt.Printf("Activating ForceSleep on KronosApp: name=%s in namespace=%s \n", name, namespace)
+
+		regexPattern := flags[0]
+		namespace := flags[1]
+		name := flags[2]
+
 		err, client := utils.InitializeClientConfig()
 		if err != nil {
 			fmt.Println("ERROR", err)
 			os.Exit(1)
 		}
-		crdApi := utils.GetCrdApiUrl(name, namespace)
-		err, sd := utils.GetKronosAppByName(client, crdApi)
-		if err != nil {
-			fmt.Println("ERROR", err)
-			os.Exit(1)
+
+		if regexPattern != "" {
+			regex := regexp.MustCompile(regexPattern)
+			err = utils.ApplyActionOnSpecByPattern(client, *regex, namespace, spec, action)
+			if err != nil {
+				fmt.Println("ERROR", err)
+				os.Exit(1)
+			}
+			os.Exit(0)
+		} else {
+			err = utils.ApplyActionOnSpecByName(client, name, namespace, spec, action)
+			if err != nil {
+				fmt.Println("ERROR", err)
+				os.Exit(1)
+			}
+			os.Exit(0)
 		}
-		if sd.Spec.ForceSleep {
-			fmt.Println(utils.GetWarningMessage("ForceSleep", "on", name))
-			os.Exit(1)
-		}
-		err = utils.PerformingActionOnSpec(client, &sd, crdApi, "sleep", "on")
-		if err != nil {
-			fmt.Println("ERROR ", err)
-			os.Exit(1)
-		}
-		fmt.Println(utils.GetSuccessMessage("ForceSleep", "on", name))
 	},
 }
 
 func init() {
 	onCmd.Flags().StringVarP(&resourceNameOn, "name", "n", "", "The KronosApp name you want to modify")
 	onCmd.Flags().StringVarP(&resourceNamespaceOn, "namespace", "", "", "The KronosApp namespace you want to modify")
+	onCmd.Flags().StringVarP(&matchRegexOn, "match-regex", "", "", "Pattern, applied on name, used to regroup KronosApps you want to modify")
 
-	if err := onCmd.MarkFlagRequired("name"); err != nil {
-		fmt.Println(err)
-	}
-	if err := onCmd.MarkFlagRequired("namespace"); err != nil {
-		fmt.Println(err)
+	onCmd.PreRunE = func(cmd *cobra.Command, args []string) error {
+		if matchRegexOn != "" {
+			if resourceNameOn != "" {
+				return fmt.Errorf("the --match-regex flag cannot be used with the --name flag")
+			}
+		} else {
+			if resourceNameOn == "" || resourceNamespaceOn == "" {
+				return fmt.Errorf("both --name and --namespace flags are required unless --match-regex is used")
+			}
+		}
+		return nil
 	}
 	ForceSleepCmd.AddCommand(onCmd)
 

--- a/cmd/forceWake/off.go
+++ b/cmd/forceWake/off.go
@@ -27,7 +27,7 @@ var offCmd = &cobra.Command{
 Example:
 $ kronos-cli forceWake off --name=my-kronosapp --namespace=my-namespace`,
 	Run: func(cmd *cobra.Command, args []string) {
-		spec := "wake"
+		spec := "ForceWake"
 		action := "off"
 
 		flags, err := utils.GetFlagNames(cmd)
@@ -41,7 +41,7 @@ $ kronos-cli forceWake off --name=my-kronosapp --namespace=my-namespace`,
 
 		err, client := utils.InitializeClientConfig()
 		if err != nil {
-			fmt.Println("ERROR", err)
+			fmt.Println("ERROR ", err)
 			os.Exit(1)
 		}
 
@@ -49,14 +49,14 @@ $ kronos-cli forceWake off --name=my-kronosapp --namespace=my-namespace`,
 			regex := regexp.MustCompile(regexPattern)
 			err = utils.ApplyActionOnSpecByPattern(client, *regex, namespace, spec, action)
 			if err != nil {
-				fmt.Println("ERROR", err)
+				fmt.Println("ERROR ", err)
 				os.Exit(1)
 			}
 			os.Exit(0)
 		} else {
 			err = utils.ApplyActionOnSpecByName(client, name, namespace, spec, action)
 			if err != nil {
-				fmt.Println("ERROR", err)
+				fmt.Println("ERROR ", err)
 				os.Exit(1)
 			}
 			os.Exit(0)
@@ -65,11 +65,11 @@ $ kronos-cli forceWake off --name=my-kronosapp --namespace=my-namespace`,
 }
 
 func init() {
-	onCmd.Flags().StringVarP(&resourceNameOff, "name", "n", "", "The KronosApp name you want to modify")
-	onCmd.Flags().StringVarP(&resourceNamespaceOff, "namespace", "", "", "The KronosApp namespace you want to modify")
-	onCmd.Flags().StringVarP(&matchRegexOff, "match-regex", "", "", "Pattern, applied on name, used to regroup KronosApps you want to modify")
+	offCmd.Flags().StringVarP(&resourceNameOff, "name", "n", "", "The KronosApp name you want to modify")
+	offCmd.Flags().StringVarP(&resourceNamespaceOff, "namespace", "", "", "The KronosApp namespace you want to modify")
+	offCmd.Flags().StringVarP(&matchRegexOff, "match-regex", "", "", "Pattern, applied on name, used to regroup KronosApps you want to modify")
 
-	onCmd.PreRunE = func(cmd *cobra.Command, args []string) error {
+	offCmd.PreRunE = func(cmd *cobra.Command, args []string) error {
 		if matchRegexOff != "" {
 			if resourceNameOff != "" {
 				return fmt.Errorf("the --match-regex flag cannot be used with the --name flag")

--- a/cmd/forceWake/off.go
+++ b/cmd/forceWake/off.go
@@ -6,6 +6,7 @@ package forceWake
 import (
 	"fmt"
 	"os"
+	"regexp"
 
 	"github.com/KronosOrg/kronos-cli/cmd/utils"
 	"github.com/spf13/cobra"
@@ -14,6 +15,7 @@ import (
 var (
 	resourceNameOff      string
 	resourceNamespaceOff string
+	matchRegexOff        string
 )
 
 // offCmd represents the off command
@@ -25,43 +27,59 @@ var offCmd = &cobra.Command{
 Example:
 $ kronos-cli forceWake off --name=my-kronosapp --namespace=my-namespace`,
 	Run: func(cmd *cobra.Command, args []string) {
-		name, namespace, err := utils.GetFlagNames(cmd)
+		spec := "wake"
+		action := "off"
+
+		flags, err := utils.GetFlagNames(cmd)
 		if err != nil {
 			fmt.Println(err)
 		}
-		fmt.Printf("Deactivating ForceWake on KronosApp: name=%s in namespace=%s \n", name, namespace)
+
+		regexPattern := flags[0]
+		namespace := flags[1]
+		name := flags[2]
+
 		err, client := utils.InitializeClientConfig()
 		if err != nil {
 			fmt.Println("ERROR", err)
 			os.Exit(1)
 		}
-		crdApi := utils.GetCrdApiUrl(name, namespace)
-		err, sd := utils.GetKronosAppByName(client, crdApi)
-		if err != nil {
-			fmt.Println(err)
+
+		if regexPattern != "" {
+			regex := regexp.MustCompile(regexPattern)
+			err = utils.ApplyActionOnSpecByPattern(client, *regex, namespace, spec, action)
+			if err != nil {
+				fmt.Println("ERROR", err)
+				os.Exit(1)
+			}
+			os.Exit(0)
+		} else {
+			err = utils.ApplyActionOnSpecByName(client, name, namespace, spec, action)
+			if err != nil {
+				fmt.Println("ERROR", err)
+				os.Exit(1)
+			}
+			os.Exit(0)
 		}
-		if !sd.Spec.ForceWake {
-			fmt.Println(utils.GetWarningMessage("ForceWake", "off", name))
-			os.Exit(1)
-		}
-		err = utils.PerformingActionOnSpec(client, &sd, crdApi, "wake", "off")
-		if err != nil {
-			fmt.Println("ERROR ", err)
-			os.Exit(1)
-		}
-		fmt.Println(utils.GetSuccessMessage("ForceWake", "off", name))
 	},
 }
 
 func init() {
-	offCmd.Flags().StringVarP(&resourceNameOff, "name", "n", "", "The KronosApp name you want to modify")
-	offCmd.Flags().StringVarP(&resourceNamespaceOff, "namespace", "", "", "The KronosApp namespace you want to modify")
+	onCmd.Flags().StringVarP(&resourceNameOff, "name", "n", "", "The KronosApp name you want to modify")
+	onCmd.Flags().StringVarP(&resourceNamespaceOff, "namespace", "", "", "The KronosApp namespace you want to modify")
+	onCmd.Flags().StringVarP(&matchRegexOff, "match-regex", "", "", "Pattern, applied on name, used to regroup KronosApps you want to modify")
 
-	if err := offCmd.MarkFlagRequired("name"); err != nil {
-		fmt.Println(err)
-	}
-	if err := offCmd.MarkFlagRequired("namespace"); err != nil {
-		fmt.Println(err)
+	onCmd.PreRunE = func(cmd *cobra.Command, args []string) error {
+		if matchRegexOff != "" {
+			if resourceNameOff != "" {
+				return fmt.Errorf("the --match-regex flag cannot be used with the --name flag")
+			}
+		} else {
+			if resourceNameOff == "" || resourceNamespaceOff == "" {
+				return fmt.Errorf("both --name and --namespace flags are required unless --match-regex is used")
+			}
+		}
+		return nil
 	}
 
 	ForceWakeCmd.AddCommand(offCmd)

--- a/cmd/forceWake/on.go
+++ b/cmd/forceWake/on.go
@@ -6,6 +6,7 @@ package forceWake
 import (
 	"fmt"
 	"os"
+	"regexp"
 
 	"github.com/KronosOrg/kronos-cli/cmd/utils"
 	"github.com/spf13/cobra"
@@ -14,6 +15,7 @@ import (
 var (
 	resourceNameOn      string
 	resourceNamespaceOn string
+	matchRegexOn        string
 )
 
 // onCmd represents the on command
@@ -25,43 +27,60 @@ var onCmd = &cobra.Command{
 Example:
 $ kronos-cli forceWake on --name=my-kronosapp --namespace=my-namespace`,
 	Run: func(cmd *cobra.Command, args []string) {
-		name, namespace, err := utils.GetFlagNames(cmd)
+		spec := "wake"
+		action := "on"
+
+		flags, err := utils.GetFlagNames(cmd)
 		if err != nil {
 			fmt.Println(err)
 		}
-		fmt.Printf("Activating ForceWake on KronosApp: name=%s in namespace=%s \n", name, namespace)
+
+		regexPattern := flags[0]
+		namespace := flags[1]
+		name := flags[2]
+
 		err, client := utils.InitializeClientConfig()
 		if err != nil {
 			fmt.Println("ERROR", err)
 			os.Exit(1)
 		}
-		crdApi := utils.GetCrdApiUrl(name, namespace)
-		err, sd := utils.GetKronosAppByName(client, crdApi)
-		if err != nil {
-			fmt.Println(err)
+
+		if regexPattern != "" {
+			regex := regexp.MustCompile(regexPattern)
+			err = utils.ApplyActionOnSpecByPattern(client, *regex, namespace, spec, action)
+			if err != nil {
+				fmt.Println("ERROR", err)
+				os.Exit(1)
+			}
+			os.Exit(0)
+		} else {
+			err = utils.ApplyActionOnSpecByName(client, name, namespace, spec, action)
+			if err != nil {
+				fmt.Println("ERROR", err)
+				os.Exit(1)
+			}
+			os.Exit(0)
 		}
-		if sd.Spec.ForceWake {
-			fmt.Println(utils.GetWarningMessage("ForceWake", "on", name))
-			os.Exit(1)
-		}
-		err = utils.PerformingActionOnSpec(client, &sd, crdApi, "wake", "on")
-		if err != nil {
-			fmt.Println("ERROR ", err)
-			os.Exit(1)
-		}
-		fmt.Println(utils.GetSuccessMessage("ForceWake", "on", name))
 	},
 }
 
 func init() {
 	onCmd.Flags().StringVarP(&resourceNameOn, "name", "n", "", "The KronosApp name you want to modify")
 	onCmd.Flags().StringVarP(&resourceNamespaceOn, "namespace", "", "", "The KronosApp namespace you want to modify")
+	onCmd.Flags().StringVarP(&matchRegexOn, "match-regex", "", "", "Pattern, applied on name, used to regroup KronosApps you want to modify")
 
-	if err := onCmd.MarkFlagRequired("name"); err != nil {
-		fmt.Println(err)
+	onCmd.PreRunE = func(cmd *cobra.Command, args []string) error {
+		if matchRegexOn != "" {
+			if resourceNameOn != "" {
+				return fmt.Errorf("the --match-regex flag cannot be used with the --name flag")
+			}
+		} else {
+			if resourceNameOn == "" || resourceNamespaceOn == "" {
+				return fmt.Errorf("both --name and --namespace flags are required unless --match-regex is used")
+			}
+		}
+		return nil
 	}
-	if err := onCmd.MarkFlagRequired("namespace"); err != nil {
-		fmt.Println(err)
-	}
+
 	ForceWakeCmd.AddCommand(onCmd)
 }

--- a/cmd/forceWake/on.go
+++ b/cmd/forceWake/on.go
@@ -27,7 +27,7 @@ var onCmd = &cobra.Command{
 Example:
 $ kronos-cli forceWake on --name=my-kronosapp --namespace=my-namespace`,
 	Run: func(cmd *cobra.Command, args []string) {
-		spec := "wake"
+		spec := "ForceWake"
 		action := "on"
 
 		flags, err := utils.GetFlagNames(cmd)

--- a/cmd/utils/utils.go
+++ b/cmd/utils/utils.go
@@ -5,14 +5,16 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
 	"github.com/KronosOrg/kronos-cli/cmd/structs"
 	"github.com/spf13/cobra"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
-	"os"
-	"path/filepath"
-	"strings"
 )
 
 func GetSuccessMessage(spec, action, name string) string {
@@ -24,20 +26,40 @@ func GetWarningMessage(spec, action, name string) string {
 }
 
 func GetCrdApiUrl(name, namespace string) string {
-	crdApi := fmt.Sprintf("/apis/core.wecraft.tn/v1alpha1/namespaces/%s/kronosapps/%s", namespace, name)
-	return crdApi
+	namespaceParam := ""
+	if namespace != "" {
+		namespaceParam = fmt.Sprintf("/namespaces/%s", namespace)
+	}
+	nameParam := ""
+	if name != "" {
+		nameParam = name
+	}
+	crdApiUrl := fmt.Sprintf("/apis/core.wecraft.tn/v1alpha1%s/kronosapps/%s", namespaceParam, nameParam)
+	return crdApiUrl
 }
 
-func GetFlagNames(cmd *cobra.Command) (string, string, error) {
-	name, err := cmd.Flags().GetString("name")
-	if err != nil {
-		return "", "", err
-	}
+func GetFlagNames(cmd *cobra.Command) ([]string, error) {
+	flags := make([]string, 3)
 	namespace, err := cmd.Flags().GetString("namespace")
 	if err != nil {
-		return "", "", err
+		return flags, err
 	}
-	return name, namespace, nil
+	flags[1] = namespace
+	matchRegex, err := cmd.Flags().GetString("match-regex")
+	if err != nil {
+		return flags, err
+	}
+	if matchRegex != "" {
+		flags[0] = matchRegex
+		return flags, nil
+	}
+	name, err := cmd.Flags().GetString("name")
+	if err != nil {
+		return flags, err
+	}
+	flags[2] = name
+
+	return flags, nil
 }
 func InitializeClientConfig() (error, *kubernetes.Clientset) {
 	var kubeconfig string
@@ -119,6 +141,233 @@ func PerformingActionOnSpec(clientset *kubernetes.Clientset, sd *structs.KronosA
 	_, err = clientset.RESTClient().Put().AbsPath(crdApi).Body(sdBytes).DoRaw(context.TODO())
 	if err != nil {
 		return err
+	}
+	return nil
+}
+
+func GetAllKronosApps(clientset *kubernetes.Clientset, namespace string) (error, structs.KronosAppList) {
+	kl := structs.KronosAppList{}
+	apiUrl := GetCrdApiUrl("", namespace)
+	kl_bytes, err := clientset.RESTClient().Get().AbsPath(apiUrl).DoRaw(context.TODO())
+	if err != nil {
+		return err, structs.KronosAppList{}
+	}
+	if err := json.Unmarshal(kl_bytes, &kl); err != nil {
+		return err, structs.KronosAppList{}
+	}
+	return nil, kl
+}
+
+func GetKronosAppsByPattern(list structs.KronosAppList, regex regexp.Regexp, namespace string) (error, structs.KronosAppList) {
+	var filteredList structs.KronosAppList
+	for _, kronosapp := range list.Items {
+		if regex.MatchString(kronosapp.Name) {
+			filteredList.Items = append(filteredList.Items, kronosapp)
+		}
+	}
+	return nil, filteredList
+}
+
+func GetKronosAppsNames(list structs.KronosAppList) []string {
+	kronosappsNames := make([]string, len(list.Items))
+	for index, kronosapp := range list.Items {
+		kronosappsNames[index] = kronosapp.Name
+	}
+	return kronosappsNames
+}
+
+func DisplayAction(name, namespace string, kronosapps structs.KronosAppList) {
+	kronosappsNames := GetKronosAppsNames(kronosapps)
+	var namespaceInfo string
+	if namespace != "" {
+		namespaceInfo = " in namespace " + namespace
+	}
+	if len(kronosappsNames) != 1 {
+		counter := 5
+		fmt.Printf("Activating ForceWake on the following KronosApps%s: \n", namespaceInfo)
+		if counter > len(kronosappsNames) {
+			counter = len(kronosappsNames)
+		}
+		for i := 0; i < counter; i++ {
+			fmt.Printf("- %s\n", kronosappsNames[i])
+		}
+		if counter < len(kronosappsNames) {
+			fmt.Printf("...more(%d)\n", len(kronosappsNames)-counter)
+		}
+	} else {
+		DisplayActionByName(kronosappsNames[0], namespace)
+	}
+}
+
+func DisplayActionByName(name, namespace string) {
+	fmt.Printf("Activating ForceWake on KronosApp %s in namespace %s \n", name, namespace)
+}
+
+func CheckIfListIsEmpty(list structs.KronosAppList, namespace string) {
+	plural := ""
+	if namespace == "" {
+		namespace = "all"
+		plural = "s"
+	}
+	if len(list.Items) == 0 {
+		fmt.Printf("No resources found in %s namespace%s.\n", namespace, plural)
+		os.Exit(0)
+	}
+}
+
+func ApplyActionOnSpecByPattern(clientset *kubernetes.Clientset, regex regexp.Regexp, namespace, spec, action string) error {
+	err, allKronosApps := GetAllKronosApps(clientset, namespace)
+	if err != nil {
+		return err
+	}
+
+	CheckIfListIsEmpty(allKronosApps, namespace)
+
+	err, targetKronosApps := GetKronosAppsByPattern(allKronosApps, regex, namespace)
+	if err != nil {
+		return err
+	}
+
+	CheckIfListIsEmpty(targetKronosApps, namespace)
+
+	DisplayAction("", namespace, targetKronosApps)
+
+	var kronosappsUnderEffect []string
+	var filteredKronosApps structs.KronosAppList
+	for _, targetKronosApp := range targetKronosApps.Items {
+		kronosAppUnderEffect, kronosApp := CheckIfActionEffectExist(targetKronosApp, spec, action)
+		if kronosAppUnderEffect != "" {
+			kronosappsUnderEffect = append(kronosappsUnderEffect, kronosAppUnderEffect)
+		} else {
+			filteredKronosApps.Items = append(filteredKronosApps.Items, *kronosApp)
+		}
+	}
+
+	if len(kronosappsUnderEffect) == len(targetKronosApps.Items) {
+		return fmt.Errorf("All targeted resources are already %s %s.", action, spec)
+	}
+
+	if len(kronosappsUnderEffect) != 0 {
+		DisplayUnchangedKronosApps(kronosappsUnderEffect, spec, action)
+	}
+
+	apiUrl := GetCrdApiUrl("", namespace)
+	var failedActions []string
+	for _, kronosapp := range filteredKronosApps.Items {
+		err = PerformingActionOnSpec(clientset, &kronosapp, apiUrl, spec, action)
+		if err != nil {
+			failedActions = append(failedActions, kronosapp.Name)
+		}
+	}
+	if len(failedActions) != 0 {
+		err = DisplayFailedActions(failedActions, filteredKronosApps, spec, action)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func CheckIfActionEffectExist(kronosapp structs.KronosApp, spec, action string) (string, *structs.KronosApp) {
+	switch spec {
+	case "wake":
+		{
+			switch action {
+			case "on":
+				{
+					if kronosapp.Spec.ForceWake {
+						return kronosapp.Name, nil
+					} else {
+						return "", &kronosapp
+					}
+				}
+			case "off":
+				{
+					if !kronosapp.Spec.ForceWake {
+						return kronosapp.Name, nil
+					} else {
+						return "", &kronosapp
+					}
+				}
+			}
+		}
+	case "sleep":
+		{
+			switch action {
+			case "on":
+				{
+					if kronosapp.Spec.ForceSleep {
+						return kronosapp.Name, nil
+					} else {
+						return "", &kronosapp
+					}
+				}
+			case "off":
+				{
+					if !kronosapp.Spec.ForceSleep {
+						return kronosapp.Name, nil
+					} else {
+						return "", &kronosapp
+					}
+				}
+			}
+		}
+	}
+	return "", nil
+}
+
+func DisplayUnchangedKronosApps(namesList []string, spec, action string) {
+	fmt.Printf("The following resources are already %s %s.\n", action, spec)
+	for _, itemName := range namesList {
+		fmt.Printf("- %s\n", itemName)
+	}
+}
+
+func DisplayUnchangedKronosApp(name, spec, action string) error {
+	return fmt.Errorf("The following resource is already %s %s: KronosApp: %s\n", action, spec, name)
+}
+
+func DisplayActionError(spec, action, name string) error {
+	var verb string
+	if action == "on" {
+		verb = "enabling"
+	} else if action == "off" {
+		verb = "disabling"
+	}
+	if name != "" {
+		return fmt.Errorf("Error %s %s on targeted resource: KronosApp: %s.", verb, spec, name)
+	}
+	return fmt.Errorf("Error %s %s on targeted resources.", verb, spec)
+}
+
+func DisplayFailedActions(failedActions []string, filteredKronosApps structs.KronosAppList, spec, action string) error {
+	if len(failedActions) == len(filteredKronosApps.Items) {
+		return DisplayActionError(spec, action, "")
+	}
+	fmt.Println("Error applying changes on the following resources:")
+	for _, failedAction := range failedActions {
+		fmt.Printf("- %s\n", failedAction)
+	}
+	return nil
+}
+
+func ApplyActionOnSpecByName(clientset *kubernetes.Clientset, name, namespace, spec, action string) error {
+	// var kronosappList structs.KronosAppList
+	apiUrl := GetCrdApiUrl(name, namespace)
+	err, kronosapp := GetKronosAppByName(clientset, apiUrl)
+	if err != nil {
+		return err
+	}
+	// kronosappList.Items = append(kronosappList.Items, kronosapp)
+	DisplayActionByName(name, namespace)
+	// failedActions, filteredKronosApps := CheckIfActionEffectExist(kronosappList, spec, action)
+	kronosAppUnderEffect, kronosApp := CheckIfActionEffectExist(kronosapp, spec, action)
+	if kronosAppUnderEffect != "" {
+		return DisplayUnchangedKronosApp(name, spec, action)
+	}
+	err = PerformingActionOnSpec(clientset, kronosApp, apiUrl, spec, action)
+	if err != nil {
+		return DisplayActionError(spec, action, name)
 	}
 	return nil
 }


### PR DESCRIPTION
This merge introduces a significant enhancement to the Kronos CLI, adding the ability to regroup KronosApp resources using regex patterns. This new feature provides users with greater flexibility and efficiency when managing multiple KronosApp instances, allowing them to apply the same effect across a group of resources that match a specified regex pattern.